### PR TITLE
Let people trust the localhost certificate instead of only clicking past it

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ Your browser will warn once about the certificate on localhost, which the
 server made for itself because Enable Banking requires https for the bank
 redirect. Continue past it. Say "connect my bank" and log in at your bank.
 
+To stop the warning coming back, trust that certificate once:
+
+```bash
+npx bankmcp trust        # macOS; asks for your password. --remove undoes it
+```
+
+Nothing installs a trust anchor on its own, so this is yours to opt into. If
+you would rather use a certificate your browser already trusts, point
+`TLS_CERT_PATH` and `TLS_KEY_PATH` at one (`mkcert localhost 127.0.0.1`
+produces a good one) and the server will use it instead of generating its own.
+
 State lives in `~/.bankmcp`. Delete the folder to forget everything.
 
 ### On a server
@@ -276,6 +287,7 @@ npm run dev            # same, with reload and .env
 npm run check          # verify config and the Enable Banking application
 npm run hash-password  # produce ADMIN_PASSWORD_HASH
 npm run watch -- --force   # run all watches once, print what fired
+npm run trust          # trust the generated localhost certificate (macOS)
 npm test               # unit tests (node:test)
 npm run typecheck
 sh scripts/build-mcpb.sh   # Claude Desktop bundle → dist/bankmcp.mcpb

--- a/bin/bankmcp.js
+++ b/bin/bankmcp.js
@@ -5,4 +5,12 @@ if (major < 24) {
   console.error(`BankMCP needs Node 24 or newer (you have ${process.versions.node}).`);
   process.exit(1);
 }
-await import("../dist/lib/stdio.js");
+// A bare `bankmcp` is the stdio server an MCP client launches. Anything with
+// arguments is a command for the person at the keyboard, and those look in the
+// same place the local server keeps its state.
+if (process.argv.length > 2) {
+  process.env.BANKMCP_LOCAL ??= "1";
+  await import("../dist/lib/cli.js");
+} else {
+  await import("../dist/lib/stdio.js");
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check": "node --env-file-if-exists=.env src/cli.ts check",
     "hash-password": "node src/cli.ts hash-password",
     "watch": "node --env-file-if-exists=.env src/cli.ts watch",
+    "trust": "node --env-file-if-exists=.env src/cli.ts trust",
     "test": "node --test test/*.test.ts",
     "typecheck": "tsc --noEmit",
     "chat": "node --env-file-if-exists=.env scripts/local-chat.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,10 @@
 //   node src/cli.ts check               → verifies config and the Enable Banking application
 //   node src/cli.ts watch [--force]     → runs all watches once and prints what fired
 import { createInterface } from "node:readline";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { config, setupProblems } from "./config.ts";
 import { eb, EnableBankingError } from "./enablebanking.ts";
 import { hashPassword } from "./auth.ts";
@@ -86,7 +90,36 @@ switch (command) {
     console.log(JSON.stringify(await runWatches({ force: args.includes("--force") }), null, 2));
     break;
   }
+  // The generated certificate is valid but self-signed, so a browser still
+  // warns about the issuer on every visit. Trusting it is a deliberate step
+  // the account holder takes for their own machine, never something the
+  // server should do to a trust store on its own.
+  case "trust": {
+    const certPath = join(config.dataDir, "localhost-cert.pem");
+    if (!existsSync(certPath)) {
+      console.error(`No certificate at ${certPath} yet. Start the server once so it can generate one.`);
+      process.exit(1);
+    }
+    if (process.platform !== "darwin") {
+      console.log(`This shortcut only knows macOS. The certificate is at:\n  ${certPath}`);
+      console.log("On Linux add it with `certutil -d sql:$HOME/.pki/nssdb -A -t P -n bankmcp -i <cert>`, on Windows with `certutil -addstore -user Root <cert>`.");
+      process.exit(1);
+    }
+    const remove = args.includes("--remove");
+    const argv = remove
+      ? ["remove-trusted-cert", certPath]
+      : ["add-trusted-cert", "-r", "trustRoot", "-k", join(homedir(), "Library/Keychains/login.keychain-db"), certPath];
+    console.log(remove ? "Removing the certificate from your login keychain..." : "Adding the certificate to your login keychain. macOS will ask for your password.");
+    const res = spawnSync("security", argv, { stdio: "inherit" });
+    if (res.status !== 0) {
+      console.error(`security exited with ${res.status ?? res.error?.message}.`);
+      process.exit(1);
+    }
+    console.log(remove ? "Removed. The browser will warn about the certificate again." : "Trusted. Restart the browser, then https://localhost:8080 loads without a warning.");
+    console.log("Re-run this after regenerating the certificate: trust follows the certificate, not the file name.");
+    break;
+  }
   default:
-    console.log("Usage: node src/cli.ts <hash-password [password] | check | watch [--force]>");
+    console.log("Usage: node src/cli.ts <hash-password [password] | check | watch [--force] | trust [--remove]>");
     process.exit(command ? 1 : 0);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -120,6 +120,6 @@ switch (command) {
     break;
   }
   default:
-    console.log("Usage: node src/cli.ts <hash-password [password] | check | watch [--force] | trust [--remove]>");
+    console.log("Usage: bankmcp <hash-password [password] | check | watch [--force] | trust [--remove]>");
     process.exit(command ? 1 : 0);
 }

--- a/src/local.ts
+++ b/src/local.ts
@@ -6,7 +6,7 @@ import { X509Certificate } from "node:crypto";
 import { join } from "node:path";
 import { createServer as createHttpsServer, type Server } from "node:https";
 import selfsigned from "selfsigned";
-import { config } from "./config.ts";
+import { config, tlsOptions } from "./config.ts";
 import { createApp } from "./app.ts";
 
 let server: Server | undefined;
@@ -26,6 +26,11 @@ export function certificateStillGood(pem: string, now = Date.now()): boolean {
 }
 
 async function certificate(): Promise<{ cert: string; key: string }> {
+  // An explicitly configured certificate wins, so anyone who would rather use
+  // one their browser already trusts (mkcert and friends) can point at it
+  // instead of trusting the generated one. `server.ts` already honours these.
+  const configured = tlsOptions();
+  if (configured) return configured;
   const certPath = join(config.dataDir, "localhost-cert.pem");
   const keyPath = join(config.dataDir, "localhost-key.pem");
   if (existsSync(certPath) && existsSync(keyPath)) {


### PR DESCRIPTION
Follow-up to #4, on top of 0.1.4. That PR made the warning click-through-able; this one offers a way to not see it at all. Entirely optional — nothing changes for someone who ignores it.

## Why

A self-signed certificate is warned about on every visit, because the issuer is not trusted. Nothing in the project could change that: `local.ts` always generated and used its own certificate, ignoring `TLS_CERT_PATH` and `TLS_KEY_PATH` — even though `config.ts` describes them as

```
// Optional: terminate TLS in the process itself (for running on your own
// machine). Hosted deployments normally get TLS from the platform.
```

which is exactly the local case, and `server.ts` already honours them. So the one documented way to supply your own certificate silently did nothing in the mode it was written for.

## What is in it

**`local.ts` honours `TLS_CERT_PATH` / `TLS_KEY_PATH`.** A configured certificate wins; otherwise the stored one is reused as before, subject to your `certificateStillGood` check. Anyone who would rather use a certificate their browser already trusts can now do:

```bash
mkcert localhost 127.0.0.1
TLS_CERT_PATH=./localhost.pem TLS_KEY_PATH=./localhost-key.pem npx bankmcp
```

**A `trust` command** that adds the generated certificate to the login keychain on macOS, and prints the `certutil` invocation on Linux and Windows:

```bash
npx bankmcp trust            # asks for your password
npx bankmcp trust --remove   # undoes it
```

It refuses politely when no certificate has been generated yet, and tells you to re-run it after the certificate is replaced, since trust follows the certificate rather than the path — which now matters more, because `certificateStillGood` can replace it on start.

## The one design decision worth flagging

Trusting is a command the account holder runs, never something that happens during install or on first start. A program that quietly installs a trust anchor is indistinguishable from one doing it maliciously, and the failure mode when the private key is shipped rather than generated locally is the Superfish / eDell class of vulnerability. So this stays explicit and reversible, and the default experience is unchanged: click through once, exactly as 0.1.4 already allows.

Happy to drop the CLI command and keep only the `TLS_CERT_PATH` fix if you would rather not carry a platform-specific helper.

## Testing

- `npm test` — 24/24 pass on Node 24, including your new `local-cert.test.ts`
- `npm run typecheck` — clean
- Verified `TLS_CERT_PATH`/`TLS_KEY_PATH` override in local mode: served a certificate with a marker CN and generated nothing in the data dir
- Ran `trust` for real against a scratch data dir on macOS 15: `security verify-cert` went from `CSSMERR_TP_NOT_TRUSTED` to `certificate verification successful`, with the served certificate unchanged
- Checked the no-certificate-yet path exits with a usable message

🤖 Generated with [Claude Code](https://claude.com/claude-code)