### PR TITLE
Add a trust command for the localhost certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ Your browser will warn once about the certificate on localhost, which the
 server made for itself because Enable Banking requires https for the bank
 redirect. Continue past it. Say "connect my bank" and log in at your bank.
 
+To stop the warning coming back, trust that certificate once:
+
+```bash
+npx bankmcp trust        # macOS; asks for your password. --remove undoes it
+```
+
+Nothing installs a trust anchor on its own, so this is yours to opt into. If
+you would rather use a certificate your browser already trusts, point
+`TLS_CERT_PATH` and `TLS_KEY_PATH` at one (`mkcert localhost 127.0.0.1`
+produces a good one) and the server will use it instead of generating its own.
+
 State lives in `~/.bankmcp`. Delete the folder to forget everything.
 
 ### On a server
@@ -276,6 +287,7 @@ npm run dev            # same, with reload and .env
 npm run check          # verify config and the Enable Banking application
 npm run hash-password  # produce ADMIN_PASSWORD_HASH
 npm run watch -- --force   # run all watches once, print what fired
+npm run trust          # trust the generated localhost certificate (macOS)
 npm test               # unit tests (node:test)
 npm run typecheck
 sh scripts/build-mcpb.sh   # Claude Desktop bundle → dist/bankmcp.mcpb

--- a/bin/bankmcp.js
+++ b/bin/bankmcp.js
@@ -5,4 +5,12 @@ if (major < 24) {
   console.error(`BankMCP needs Node 24 or newer (you have ${process.versions.node}).`);
   process.exit(1);
 }
-await import("../dist/lib/stdio.js");
+// A bare `bankmcp` is the stdio server an MCP client launches. Anything with
+// arguments is a command for the person at the keyboard, and those look in the
+// same place the local server keeps its state.
+if (process.argv.length > 2) {
+  process.env.BANKMCP_LOCAL ??= "1";
+  await import("../dist/lib/cli.js");
+} else {
+  await import("../dist/lib/stdio.js");
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check": "node --env-file-if-exists=.env src/cli.ts check",
     "hash-password": "node src/cli.ts hash-password",
     "watch": "node --env-file-if-exists=.env src/cli.ts watch",
+    "trust": "node --env-file-if-exists=.env src/cli.ts trust",
     "test": "node --test test/*.test.ts",
     "typecheck": "tsc --noEmit",
     "chat": "node --env-file-if-exists=.env scripts/local-chat.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,10 @@
 //   node src/cli.ts check               → verifies config and the Enable Banking application
 //   node src/cli.ts watch [--force]     → runs all watches once and prints what fired
 import { createInterface } from "node:readline";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { config, setupProblems } from "./config.ts";
 import { eb, EnableBankingError } from "./enablebanking.ts";
 import { hashPassword } from "./auth.ts";
@@ -86,7 +90,36 @@ switch (command) {
     console.log(JSON.stringify(await runWatches({ force: args.includes("--force") }), null, 2));
     break;
   }
+  // The generated certificate is valid but self-signed, so a browser still
+  // warns about the issuer on every visit. Trusting it is a deliberate step
+  // the account holder takes for their own machine, never something the
+  // server should do to a trust store on its own.
+  case "trust": {
+    const certPath = join(config.dataDir, "localhost-cert.pem");
+    if (!existsSync(certPath)) {
+      console.error(`No certificate at ${certPath} yet. Start the server once so it can generate one.`);
+      process.exit(1);
+    }
+    if (process.platform !== "darwin") {
+      console.log(`This shortcut only knows macOS. The certificate is at:\n  ${certPath}`);
+      console.log("On Linux add it with `certutil -d sql:$HOME/.pki/nssdb -A -t P -n bankmcp -i <cert>`, on Windows with `certutil -addstore -user Root <cert>`.");
+      process.exit(1);
+    }
+    const remove = args.includes("--remove");
+    const argv = remove
+      ? ["remove-trusted-cert", certPath]
+      : ["add-trusted-cert", "-r", "trustRoot", "-k", join(homedir(), "Library/Keychains/login.keychain-db"), certPath];
+    console.log(remove ? "Removing the certificate from your login keychain..." : "Adding the certificate to your login keychain. macOS will ask for your password.");
+    const res = spawnSync("security", argv, { stdio: "inherit" });
+    if (res.status !== 0) {
+      console.error(`security exited with ${res.status ?? res.error?.message}.`);
+      process.exit(1);
+    }
+    console.log(remove ? "Removed. The browser will warn about the certificate again." : "Trusted. Restart the browser, then https://localhost:8080 loads without a warning.");
+    console.log("Re-run this after regenerating the certificate: trust follows the certificate, not the file name.");
+    break;
+  }
   default:
-    console.log("Usage: node src/cli.ts <hash-password [password] | check | watch [--force]>");
+    console.log("Usage: bankmcp <hash-password [password] | check | watch [--force] | trust [--remove]>");
     process.exit(command ? 1 : 0);
 }

--- a/src/local.ts
+++ b/src/local.ts
@@ -6,7 +6,7 @@ import { X509Certificate } from "node:crypto";
 import { join } from "node:path";
 import { createServer as createHttpsServer, type Server } from "node:https";
 import selfsigned from "selfsigned";
-import { config } from "./config.ts";
+import { config, tlsOptions } from "./config.ts";
 import { createApp } from "./app.ts";
 
 let server: Server | undefined;
@@ -26,6 +26,11 @@ export function certificateStillGood(pem: string, now = Date.now()): boolean {
 }
 
 async function certificate(): Promise<{ cert: string; key: string }> {
+  // An explicitly configured certificate wins, so anyone who would rather use
+  // one their browser already trusts (mkcert and friends) can point at it
+  // instead of trusting the generated one. `server.ts` already honours these.
+  const configured = tlsOptions();
+  if (configured) return configured;
   const certPath = join(config.dataDir, "localhost-cert.pem");
   const keyPath = join(config.dataDir, "localhost-key.pem");
   if (existsSync(certPath) && existsSync(keyPath)) {


### PR DESCRIPTION
Follow-up to #4, on top of 0.1.4. That PR made the certificate warning click-through-able; this makes it possible to not see it at all. Optional — ignoring it costs one click, exactly as today.

## What was edited

| File | Change |
|---|---|
| `src/local.ts` | Honour `TLS_CERT_PATH` / `TLS_KEY_PATH` in local mode. A configured certificate wins; otherwise the stored one is reused as before, still subject to `certificateStillGood`. |
| `src/cli.ts` | New `trust` and `trust --remove`. Adds or removes the certificate in the login keychain on macOS; prints the `certutil` invocation on Linux and Windows. Refuses cleanly when no certificate exists yet. |
| `bin/bankmcp.js` | `bankmcp <command>` now reaches the CLI, in local mode so it looks in `~/.bankmcp`. A bare `bankmcp` still starts the stdio server. |
| `package.json` | `npm run trust`. |
| `README.md` | Four lines documenting both routes. |

62 lines added, 3 changed. No test files touched.

## Why local.ts needed changing

`config.ts` documents those two variables as

```
// Optional: terminate TLS in the process itself (for running on your own
// machine).
```

which is exactly the local case, and `server.ts` already honours them — but `local.ts` did not. So the one documented way to supply your own certificate silently did nothing in the mode it was written for. With this, `mkcert localhost 127.0.0.1` output can be pointed at directly and no trust command is needed at all.

## Testing

- 24/24 tests and typecheck clean, including `local-cert.test.ts`
- `TLS_CERT_PATH`/`TLS_KEY_PATH` override: served a certificate with a marker CN, generated none in the data dir
- `trust` run for real on macOS 15: `security verify-cert` went `CSSMERR_TP_NOT_TRUSTED` → `certificate verification successful`, served certificate unchanged; `--remove` returned it to `CSSMERR_TP_NOT_TRUSTED`
- `bankmcp trust` dispatch verified end to end after building: resolves `dataDir` to `~/.bankmcp` rather than `./data`, and an unknown command prints usage

This replaces #5, which I opened before finding the `bin/bankmcp.js` problem — the command it documented could not actually run. Same change, one commit, that bug fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)