### PR TITLE
Stop exporting three helpers nothing outside their file uses

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -93,4 +93,4 @@ export function daysAgo(n: number): string {
   return isoDate(new Date(Date.now() - n * 86_400_000));
 }
 
-export const round2 = (n: number) => Math.round(n * 100) / 100;
+const round2 = (n: number) => Math.round(n * 100) / 100;

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -2,7 +2,7 @@
 // result of a bank connection, and a status page. No external assets.
 import { config } from "./config.ts";
 
-export const esc = (s: string) => s.replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!);
+const esc = (s: string) => s.replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!);
 
 type Kind = "ok" | "error" | "neutral";
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -15,7 +15,7 @@ const fail = (message: string) => ({ content: [{ type: "text" as const, text: me
 class ToolError extends Error {}
 
 /** Accepts an account uid, or your label / the bank's name / IBAN (case-insensitive). */
-export function resolveAccount(ref: string): StoredAccount {
+function resolveAccount(ref: string): StoredAccount {
   const s = store();
   const direct = s.account(ref);
   if (direct) return direct;


### PR DESCRIPTION
Small tidy, no behaviour change. Three one-word diffs.

| File | Symbol | Local uses | External uses |
|---|---|---|---|
| `src/pages.ts` | `esc` | 25 | 0 |
| `src/data.ts` | `round2` | 5 | 0 |
| `src/tools.ts` | `resolveAccount` | 3 | 0 |

Each is only ever called in the file that defines it, so the `export` widens the package's surface for no caller.

## What I deliberately left alone

An audit for dead code turned up nothing else, which is worth saying plainly:

- `tsc --noUnusedLocals --noUnusedParameters` — zero findings
- no unused runtime dependencies (`typescript`, `@types/node`, `@types/express` are build/type-only)
- no unreferenced files (`cli.ts`, `server.ts`, `stdio.ts` are entry points via `bin` and npm scripts)
- `config.tlsCertPath` / `config.tlsKeyPath` are used only inside `config.ts`, but that is `tlsOptions()` encapsulating them, not dead code

Sixteen exported types and interfaces (`Aspsp`, `PendingAuth`, `StoreData`, `SetupInput`, …) are also referenced only in their own file, but I left every one of them: the package ships `dist/lib`, and a consumer may reasonably be importing those. Happy to drop them too if you would rather, though that is a breaking change for anyone who is.

## Testing

24/24 tests and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)